### PR TITLE
Add customizable message formatter to BaseGamePlayer

### DIFF
--- a/langchain_werewolf/main.py
+++ b/langchain_werewolf/main.py
@@ -117,7 +117,7 @@ def main(
             players=players,
             players_cfg=config_used.players,
             model=config_used.general.model,  # type: ignore
-            system_formatter=config_.general.system_formatter,  # type: ignore
+            system_formatter=config_used.general.system_formatter,  # type: ignore # noqa
             seed=config_used.general.seed,  # type: ignore
         ),
     )
@@ -159,6 +159,7 @@ def cli(
     output: str = DEFAULT_GENERAL_CONFIG.output,  # type: ignore # noqa
     cli_output_level:  str = DEFAULT_GENERAL_CONFIG.cli_output_level.name,  # type: ignore # noqa
     system_interface: str = DEFAULT_GENERAL_CONFIG.system_interface.name,  # type: ignore # noqa
+    system_formatter: str = DEFAULT_GENERAL_CONFIG.system_formatter,  # type: ignore # noqa
     config: str = '',  # type: ignore # noqa
     seed: int = DEFAULT_GENERAL_CONFIG.seed,  # type: ignore # noqa
     model: str = DEFAULT_GENERAL_CONFIG.model,  # type: ignore # noqa
@@ -181,6 +182,7 @@ def cli(
         output=output,
         cli_output_level=cli_output_level,
         system_interface=system_interface,  # type: ignore
+        system_formatter=system_formatter,
         config=config,
         seed=seed,
         model=model,

--- a/langchain_werewolf/main.py
+++ b/langchain_werewolf/main.py
@@ -7,7 +7,7 @@ import pydantic
 from .enums import ESystemOutputType, EInputOutputType
 from .game.main import create_game_graph
 from .models.config import Config,  GeneralConfig
-from .models.state import StateModel
+from .models.state import StateModel, MsgModel
 from .setup import generate_players, create_echo_runnable
 from .utils import (
     load_json,
@@ -23,6 +23,7 @@ DEFAULT_CONFIG = Config(
         output='',
         cli_output_level=ESystemOutputType.all,
         system_interface=EInputOutputType.standard,
+        system_formatter=None,
         seed=-1,
         model='gpt-4o-mini',
         recursion_limit=1000,
@@ -41,6 +42,7 @@ def main(
     output: str = DEFAULT_GENERAL_CONFIG.output,  # type: ignore # noqa
     cli_output_level:  ESystemOutputType | str = DEFAULT_GENERAL_CONFIG.cli_output_level,  # type: ignore # noqa
     system_interface: EInputOutputType = DEFAULT_GENERAL_CONFIG.system_interface,  # type: ignore # noqa
+    system_formatter: str | None = DEFAULT_GENERAL_CONFIG.system_formatter,  # type: ignore # noqa
     config: str = '',
     seed: int = DEFAULT_GENERAL_CONFIG.seed,  # type: ignore # noqa
     model: str = DEFAULT_GENERAL_CONFIG.model,  # type: ignore # noqa
@@ -66,6 +68,7 @@ def main(
             output=output,
             cli_output_level=cli_output_level,
             system_interface=system_interface,
+            system_formatter=system_formatter,
             seed=seed,
             model=model,
             recursion_limit=recursion_limit,
@@ -106,6 +109,7 @@ def main(
             players=players,
             players_cfg=config_.players,
             model=config_.general.model,  # type: ignore
+            system_formatter=config_.general.system_formatter,  # type: ignore
             seed=config_.general.seed,  # type: ignore
         ),  # noqa
     )
@@ -132,6 +136,7 @@ def main(
 @click.option('-o', '--output', default=DEFAULT_GENERAL_CONFIG.output, help=f'The output file. Defaults to "{DEFAULT_GENERAL_CONFIG.output}".')  # noqa
 @click.option('-l', '--cli-output-level', default=DEFAULT_GENERAL_CONFIG.cli_output_level.name if isinstance(DEFAULT_GENERAL_CONFIG.cli_output_level, ESystemOutputType) else DEFAULT_GENERAL_CONFIG.cli_output_level, help=f'The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is All.')  # noqa
 @click.option('--system-interface', default=DEFAULT_GENERAL_CONFIG.system_interface.name if isinstance(DEFAULT_GENERAL_CONFIG.system_interface, EInputOutputType) else DEFAULT_GENERAL_CONFIG.system_interface, help=f'The system interface. Default is {DEFAULT_GENERAL_CONFIG.system_interface}.')  # noqa
+@click.option('--system-formatter', default=DEFAULT_GENERAL_CONFIG.system_formatter, help=f'The system formatter. The format should not include anything other than ' + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()) + '.')  # noqa
 @click.option('-c', '--config', default='', help='The configuration file. Defaults to "". Note that you can specify CLI arguments in this config file but the config file overwrite the CLI arguments.')  # noqa
 @click.option('--seed', default=DEFAULT_GENERAL_CONFIG.seed, help=f'The random seed. Defaults to {DEFAULT_GENERAL_CONFIG.seed}.')  # noqa
 @click.option('--model', default=DEFAULT_GENERAL_CONFIG.model, help=f'The model to use. Default is {DEFAULT_GENERAL_CONFIG.model}.')  # noqa

--- a/langchain_werewolf/models/config.py
+++ b/langchain_werewolf/models/config.py
@@ -21,6 +21,7 @@ class GeneralConfig(BaseModel, frozen=True):
         title=f"The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is None.",  # noqa
     )
     system_interface: EInputOutputType | None = Field(default=None, title="The system interface. Default is None.")  # noqa
+    system_formatter: str | None = Field(default=None, title="The system formatter. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
     seed: int | None = Field(default=None, title="The random seed. Defaults to None.")  # noqa
     model: str | None = Field(default=None, title=f"The model to use. Default is None.")  # noqa
     recursion_limit: int | None = Field(default=None, title="The recursion limit. Default is None.")  # noqa

--- a/langchain_werewolf/models/config.py
+++ b/langchain_werewolf/models/config.py
@@ -6,6 +6,7 @@ from ..enums import (
     ESpeakerSelectionMethod,
     ESystemOutputType,
 )
+from .state import MsgModel
 from ..utils import consecutive_string_generator
 
 
@@ -32,6 +33,7 @@ class PlayerConfig(BaseModel, frozen=True):
     role: ERole | None = Field(default=None, title="The role of the player")  # noqa
     model: str = Field(default=DEFAULT_MODEL, title=f"The model to use. Default is {DEFAULT_MODEL}.")  # noqa
     input_output_type: EInputOutputType | None = Field(default=None, title="The input output type of the player")  # noqa
+    formatter: str | None = Field(default=None, title="The formatter of the player. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
 
 
 class GameConfig(BaseModel, frozen=True):

--- a/langchain_werewolf/setup.py
+++ b/langchain_werewolf/setup.py
@@ -155,6 +155,7 @@ def generate_players(
                 if player_cfg and player_cfg.input_output_type
                 else None
             ),
+            formatter=player_cfg.formatter if player_cfg and player_cfg.formatter else None,  # noqa
         )
         for player_cfg in players_cfg
     ]

--- a/langchain_werewolf/setup.py
+++ b/langchain_werewolf/setup.py
@@ -202,7 +202,7 @@ def _create_echo_runnable_by_player(
                                 )
                             ),
                         )
-                        | RunnableLambda(lambda dic: MsgModel(**(dic['orig'] | {'message': dic['translated_msg']})))  # noqa
+                        | RunnableLambda(lambda dic: MsgModel(**(dic['orig'].model_dump() | {'message': dic['translated_msg']})))  # noqa
                         | create_output_runnable(
                             output_func=player.receive_message,
                             styler=partial(click.style, fg=color or CLI_PROMPT_COLOR),  # noqa
@@ -265,7 +265,7 @@ def _create_echo_runnable_by_system(
                 )
             ),
         ).with_types(input_type=MsgModel)
-        | RunnableLambda(lambda dic: MsgModel(**(dic['orig'] | {'message': dic['translated_msg']})))  # noqa
+        | RunnableLambda(lambda dic: MsgModel(**(dic['orig'].model_dump() | {'message': dic['translated_msg']})))  # noqa
         | formatter_runnable
     )
     # create runnable

--- a/tests/game_players/test_base.py
+++ b/tests/game_players/test_base.py
@@ -1,0 +1,124 @@
+from operator import attrgetter
+from typing import Callable
+from langchain_core.runnables import Runnable
+from pydantic import ValidationError
+import pytest
+from pytest_mock import MockerFixture
+from langchain_werewolf.enums import ERole, ESide
+from langchain_werewolf.game_players.base import (
+    BaseGamePlayer,
+    _DEFAULT_FORMATTER,
+    GamePlayerRunnableInputModel,
+)
+from langchain_werewolf.models.state import MsgModel
+
+# TODO: Add tests for BaseGamePlayer's methods
+
+
+_DUMMY_MESSAGE = MsgModel(name='name', message='message')
+
+
+def test_BaseGamePlayer_receive_message_with_default_formatter(
+    mocker: MockerFixture,
+) -> None:
+    runnable_mock = mocker.MagicMock(spec=Runnable[GamePlayerRunnableInputModel, str])  # noqa
+    output_mock = mocker.MagicMock(spec=Runnable[str, None])
+    player = BaseGamePlayer(
+        name='name',
+        role=ERole.Villager,
+        side=ESide.Villager,
+        victory_condition='victory_condition',
+        night_action='night_action',
+        question_to_decide_night_action='question_to_decide_night_action',
+        runnable=runnable_mock,
+        output=output_mock,
+    )
+    player.receive_message(_DUMMY_MESSAGE)
+    output_mock.assert_called_once_with(_DEFAULT_FORMATTER(_DUMMY_MESSAGE))
+
+
+@pytest.mark.parametrize(
+    'formatter',
+    [
+        MsgModel.format,
+        attrgetter('message'),
+    ]
+)
+def test_BaseGamePlayer_receive_message_with_callable_foratter(
+    formatter: Callable[[MsgModel], str],
+    mocker: MockerFixture,
+) -> None:
+    runnable_mock = mocker.MagicMock(spec=Runnable[GamePlayerRunnableInputModel, str])  # noqa
+    output_mock = mocker.MagicMock(spec=Runnable[str, None])
+    player = BaseGamePlayer(
+        name='name',
+        role=ERole.Villager,
+        side=ESide.Villager,
+        victory_condition='victory_condition',
+        night_action='night_action',
+        question_to_decide_night_action='question_to_decide_night_action',
+        runnable=runnable_mock,
+        output=output_mock,
+        formatter=formatter,
+    )
+    player.receive_message(_DUMMY_MESSAGE)
+    output_mock.assert_called_once_with(formatter(_DUMMY_MESSAGE))
+
+
+@pytest.mark.parametrize(
+    'formatter',
+    [
+        '{name}',
+        '{message}',
+        '{participants}',
+        '{timestamp}',
+        '{name}: {message}',
+        '{timestamp}: {name}: {message}',
+        '{timestamp}: {name}: {message}: {participants}',
+    ]
+)
+def test_BaseGamePlayer_receive_message_with_str_formatter(
+    formatter: str,
+    mocker: MockerFixture,
+) -> None:
+    runnable_mock = mocker.MagicMock(spec=Runnable[GamePlayerRunnableInputModel, str])  # noqa
+    output_mock = mocker.MagicMock(spec=Runnable[str, None])
+    player = BaseGamePlayer(
+        name='name',
+        role=ERole.Villager,
+        side=ESide.Villager,
+        victory_condition='victory_condition',
+        night_action='night_action',
+        question_to_decide_night_action='question_to_decide_night_action',
+        runnable=runnable_mock,
+        output=output_mock,
+        formatter=formatter,
+    )
+    player.receive_message(_DUMMY_MESSAGE)
+    output_mock.assert_called_once_with(formatter.format(**_DUMMY_MESSAGE.model_dump()))  # noqa
+
+
+@pytest.mark.parametrize(
+    'formatter',
+    [
+        '{not_exist}:{name}',
+    ]
+)
+def test_BaseGamePlayer_receive_message_with_invalid_formatter(
+    formatter: str,
+    mocker: MockerFixture,
+) -> None:
+    runnable_mock = mocker.MagicMock(spec=Runnable[GamePlayerRunnableInputModel, str])  # noqa
+    output_mock = mocker.MagicMock(spec=Runnable[str, None])
+    with pytest.raises(ValidationError):
+        BaseGamePlayer(
+            name='name',
+            role=ERole.Villager,
+            side=ESide.Villager,
+            victory_condition='victory_condition',
+            night_action='night_action',
+            question_to_decide_night_action='question_to_decide_night_action',
+            runnable=runnable_mock,
+            output=output_mock,
+            formatter=formatter
+        )


### PR DESCRIPTION
This pull request adds the ability to specify a customizable message formatter to the BaseGamePlayer class. The `BaseGamePlayer` class now has a new attribute `formatter` which can be a callable or a string. If it is a callable, it will be used to format the message. If it is a string, it will be used as a format string and the message model fields can be referenced using curly braces. The pull request also includes tests for the new functionality.