### PR TITLE
Refactor setup.py and config.py to support customizable system's and players' input and output interfaces

### DIFF
--- a/langchain_werewolf/main.py
+++ b/langchain_werewolf/main.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from typing import Any, Callable
 import click
 from dotenv import load_dotenv
 from langchain.globals import set_verbose, set_debug
@@ -42,8 +43,8 @@ def main(
     n_fortune_tellers: int = DEFAULT_GENERAL_CONFIG.n_fortune_tellers,  # type: ignore # noqa
     output: str = DEFAULT_GENERAL_CONFIG.output,  # type: ignore # noqa
     system_output_level:  ESystemOutputType | str = DEFAULT_GENERAL_CONFIG.system_output_level,  # type: ignore # noqa
-    system_input_interface: EInputOutputType = DEFAULT_GENERAL_CONFIG.system_input_interface,  # type: ignore # noqa
-    system_output_interface: EInputOutputType = DEFAULT_GENERAL_CONFIG.system_output_interface,  # type: ignore # noqa
+    system_output_interface: Callable[[str], None] | EInputOutputType = DEFAULT_GENERAL_CONFIG.system_output_interface,  # type: ignore # noqa
+    system_input_interface: Callable[[str], Any] | EInputOutputType = DEFAULT_GENERAL_CONFIG.system_input_interface,  # type: ignore # noqa
     system_formatter: str | None = DEFAULT_GENERAL_CONFIG.system_formatter,  # type: ignore # noqa
     config: Config | str | None = None,
     seed: int = DEFAULT_GENERAL_CONFIG.seed,  # type: ignore # noqa

--- a/langchain_werewolf/main.py
+++ b/langchain_werewolf/main.py
@@ -21,8 +21,9 @@ DEFAULT_CONFIG = Config(
         n_knights=1,
         n_fortune_tellers=1,
         output='',
-        cli_output_level=ESystemOutputType.all,
-        system_interface=EInputOutputType.standard,
+        system_output_level=ESystemOutputType.all,
+        system_output_interface=EInputOutputType.standard,
+        system_input_interface=EInputOutputType.standard,
         system_formatter=None,
         seed=-1,
         model='gpt-4o-mini',
@@ -40,8 +41,9 @@ def main(
     n_knights: int = DEFAULT_GENERAL_CONFIG.n_knights,  # type: ignore # noqa
     n_fortune_tellers: int = DEFAULT_GENERAL_CONFIG.n_fortune_tellers,  # type: ignore # noqa
     output: str = DEFAULT_GENERAL_CONFIG.output,  # type: ignore # noqa
-    cli_output_level:  ESystemOutputType | str = DEFAULT_GENERAL_CONFIG.cli_output_level,  # type: ignore # noqa
-    system_interface: EInputOutputType = DEFAULT_GENERAL_CONFIG.system_interface,  # type: ignore # noqa
+    system_output_level:  ESystemOutputType | str = DEFAULT_GENERAL_CONFIG.system_output_level,  # type: ignore # noqa
+    system_input_interface: EInputOutputType = DEFAULT_GENERAL_CONFIG.system_input_interface,  # type: ignore # noqa
+    system_output_interface: EInputOutputType = DEFAULT_GENERAL_CONFIG.system_output_interface,  # type: ignore # noqa
     system_formatter: str | None = DEFAULT_GENERAL_CONFIG.system_formatter,  # type: ignore # noqa
     config: Config | str | None = None,
     seed: int = DEFAULT_GENERAL_CONFIG.seed,  # type: ignore # noqa
@@ -72,8 +74,9 @@ def main(
             n_knights=config.general.n_knights if config.general.n_knights is not None else n_knights,  # noqa
             n_fortune_tellers=config.general.n_fortune_tellers if config.general.n_fortune_tellers is not None else n_fortune_tellers,  # noqa
             output=config.general.output if config.general.output is not None else output,  # noqa
-            cli_output_level=config.general.cli_output_level if config.general.cli_output_level is not None else cli_output_level,  # noqa
-            system_interface=config.general.system_interface if config.general.system_interface is not None else system_interface,  # noqa
+            system_output_level=config.general.system_output_level if config.general.system_output_level is not None else system_output_level,  # noqa
+            system_input_interface=config.general.system_input_interface if config.general.system_input_interface is not None else system_input_interface,  # noqa
+            system_output_interface=config.general.system_output_interface if config.general.system_output_interface is not None else system_output_interface,  # noqa
             system_formatter=config.general.system_formatter if config.general.system_formatter is not None else system_formatter,  # noqa
             seed=config.general.seed if config.general.seed is not None else seed,  # noqa
             model=config.general.model if config.general.model is not None else model,  # noqa
@@ -100,7 +103,7 @@ def main(
         config_used.general.n_fortune_tellers,  # type: ignore
         model=config_used.general.model,
         seed=config_used.general.seed,  # type: ignore
-        input_output_type=config_used.general.system_interface,  # type: ignore # noqa
+        input_output_type=config_used.general.system_input_interface,  # type: ignore # noqa
         custom_players=config_used.players,
     )
 
@@ -112,8 +115,8 @@ def main(
             for k, dic in config_used.game.model_dump().items()
         },
         echo=create_echo_runnable(
-            config_used.general.system_interface,  # type: ignore # noqa,
-            config_used.general.cli_output_level,  # type: ignore # noqa
+            config_used.general.system_output_interface,  # type: ignore # noqa,
+            config_used.general.system_output_level,  # type: ignore # noqa
             players=players,
             players_cfg=config_used.players,
             model=config_used.general.model,  # type: ignore
@@ -142,8 +145,9 @@ def main(
 @click.option('-k', '--n-knights', default=DEFAULT_GENERAL_CONFIG.n_knights, help=f'The number of knights. Default is {DEFAULT_GENERAL_CONFIG.n_knights}.')  # noqa
 @click.option('-f', '--n-fortune-tellers', default=DEFAULT_GENERAL_CONFIG.n_fortune_tellers, help=f'The number of fortune tellers. Default is {DEFAULT_GENERAL_CONFIG.n_fortune_tellers}.')  # noqa
 @click.option('-o', '--output', default=DEFAULT_GENERAL_CONFIG.output, help=f'The output file. Defaults to "{DEFAULT_GENERAL_CONFIG.output}".')  # noqa
-@click.option('-l', '--cli-output-level', default=DEFAULT_GENERAL_CONFIG.cli_output_level.name if isinstance(DEFAULT_GENERAL_CONFIG.cli_output_level, ESystemOutputType) else DEFAULT_GENERAL_CONFIG.cli_output_level, help=f'The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is All.')  # noqa
-@click.option('--system-interface', default=DEFAULT_GENERAL_CONFIG.system_interface.name if isinstance(DEFAULT_GENERAL_CONFIG.system_interface, EInputOutputType) else DEFAULT_GENERAL_CONFIG.system_interface, help=f'The system interface. Default is {DEFAULT_GENERAL_CONFIG.system_interface}.')  # noqa
+@click.option('-l', '--system-output-level', default=DEFAULT_GENERAL_CONFIG.system_output_level.name if isinstance(DEFAULT_GENERAL_CONFIG.system_output_level, ESystemOutputType) else DEFAULT_GENERAL_CONFIG.system_output_level, help=f'The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is All.')  # noqa
+@click.option('--system-output-interface', default=DEFAULT_GENERAL_CONFIG.system_output_interface.name if isinstance(DEFAULT_GENERAL_CONFIG.system_output_interface, EInputOutputType) else DEFAULT_GENERAL_CONFIG.system_output_interface, help=f'The system interface. Default is {DEFAULT_GENERAL_CONFIG.system_output_interface}.')  # noqa
+@click.option('--system-input-interface', default=DEFAULT_GENERAL_CONFIG.system_input_interface.name if isinstance(DEFAULT_GENERAL_CONFIG.system_input_interface, EInputOutputType) else DEFAULT_GENERAL_CONFIG.system_input_interface, help=f'The system interface. Default is {DEFAULT_GENERAL_CONFIG.system_input_interface}.')  # noqa
 @click.option('--system-formatter', default=DEFAULT_GENERAL_CONFIG.system_formatter, help=f'The system formatter. The format should not include anything other than ' + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()) + '.')  # noqa
 @click.option('-c', '--config', default='', help='The configuration file. Defaults to "". Note that you can specify CLI arguments in this config file but the config file overwrite the CLI arguments.')  # noqa
 @click.option('--seed', default=DEFAULT_GENERAL_CONFIG.seed, help=f'The random seed. Defaults to {DEFAULT_GENERAL_CONFIG.seed}.')  # noqa
@@ -157,8 +161,9 @@ def cli(
     n_knights: int = DEFAULT_GENERAL_CONFIG.n_knights,  # type: ignore # noqa
     n_fortune_tellers: int = DEFAULT_GENERAL_CONFIG.n_fortune_tellers,  # type: ignore # noqa
     output: str = DEFAULT_GENERAL_CONFIG.output,  # type: ignore # noqa
-    cli_output_level:  str = DEFAULT_GENERAL_CONFIG.cli_output_level.name,  # type: ignore # noqa
-    system_interface: str = DEFAULT_GENERAL_CONFIG.system_interface.name,  # type: ignore # noqa
+    system_output_level:  str = DEFAULT_GENERAL_CONFIG.system_output_level.name,  # type: ignore # noqa
+    system_output_interface: str = DEFAULT_GENERAL_CONFIG.system_output_interface.name,  # type: ignore # noqa
+    system_input_interface: str = DEFAULT_GENERAL_CONFIG.system_input_interface.name,  # type: ignore # noqa
     system_formatter: str = DEFAULT_GENERAL_CONFIG.system_formatter,  # type: ignore # noqa
     config: str = '',  # type: ignore # noqa
     seed: int = DEFAULT_GENERAL_CONFIG.seed,  # type: ignore # noqa
@@ -168,20 +173,21 @@ def cli(
     verbose: bool = False,  # type: ignore # noqa
     logger: logging.Logger = logging.getLogger(__name__),  # type: ignore # noqa,
 ):
-    if hasattr(ESystemOutputType, cli_output_level):
-        cli_output_level = ESystemOutputType(cli_output_level)  # type: ignore
-    if hasattr(EInputOutputType, system_interface):
-        system_interface = EInputOutputType(system_interface)  # type: ignore
+    if hasattr(ESystemOutputType, system_output_level):
+        system_output_level = ESystemOutputType(system_output_level)  # type: ignore # noqa
+    if hasattr(EInputOutputType, system_output_interface):
+        system_output_interface = EInputOutputType(system_output_interface)  # type: ignore  # noqa
     else:
-        raise ValueError(f'Invalid system interface: {system_interface}. Valid values are {list(EInputOutputType.__members__.keys())}.')  # noqa
+        raise ValueError(f'Invalid system interface: {system_output_interface}. Valid values are {list(EInputOutputType.__members__.keys())}.')  # noqa
     main(
         n_players=n_players,
         n_werewolves=n_werewolves,
         n_knights=n_knights,
         n_fortune_tellers=n_fortune_tellers,
         output=output,
-        cli_output_level=cli_output_level,
-        system_interface=system_interface,  # type: ignore
+        system_output_level=system_output_level,
+        system_output_interface=system_output_interface,  # type: ignore
+        system_input_interface=EInputOutputType(system_input_interface),
         system_formatter=system_formatter,
         config=config,
         seed=seed,

--- a/langchain_werewolf/models/config.py
+++ b/langchain_werewolf/models/config.py
@@ -1,3 +1,4 @@
+from typing import Any, Callable
 from pydantic import BaseModel, Field
 from ..const import DEFAULT_MODEL, CUSTOM_PLAYER_PREFIX
 from ..enums import (
@@ -17,8 +18,8 @@ class GeneralConfig(BaseModel, frozen=True):
     n_fortune_tellers: int | None = Field(default=None, title="The number of fortune tellers. Default is None.")  # noqa
     output: str | None = Field(default=None, title='The output file. Defaults to None.')  # noqa
     system_output_level: ESystemOutputType | str | None = Field(default=None, title=f"The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is None.")  # noqa
-    system_input_interface: EInputOutputType | None = Field(default=None, title="The system input interface. Default is None.")  # noqa
-    system_output_interface: EInputOutputType | None = Field(default=None, title="The system output interface. Default is None.")  # noqa
+    system_output_interface: Callable[[str], None] | EInputOutputType | None = Field(default=None, title="The system output interface. Default is None.")  # noqa
+    system_input_interface: Callable[[str], Any] | EInputOutputType | None = Field(default=None, title="The system input interface. Default is None.")  # noqa
     system_formatter: str | None = Field(default=None, title="The system formatter. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
     seed: int | None = Field(default=None, title="The random seed. Defaults to None.")  # noqa
     model: str | None = Field(default=None, title=f"The model to use. Default is None.")  # noqa
@@ -31,8 +32,8 @@ class PlayerConfig(BaseModel, frozen=True):
     name: str = Field(..., title="The name of the player", default_factory=consecutive_string_generator(CUSTOM_PLAYER_PREFIX).__next__)  # noqa
     role: ERole | None = Field(default=None, title="The role of the player")  # noqa
     model: str = Field(default=DEFAULT_MODEL, title=f"The model to use. Default is {DEFAULT_MODEL}.")  # noqa
-    player_output_interface: EInputOutputType | None = Field(default=None, title="The output interface of the player")  # noqa
-    player_input_interface: EInputOutputType | None = Field(default=None, title="The input interface of the player")  # noqa
+    player_output_interface: Callable[[str], None] | EInputOutputType | None = Field(default=None, title="The output interface of the player")  # noqa
+    player_input_interface: Callable[[str], Any] | EInputOutputType | None = Field(default=None, title="The input interface of the player")  # noqa
     formatter: str | None = Field(default=None, title="The formatter of the player. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
 
 

--- a/langchain_werewolf/models/config.py
+++ b/langchain_werewolf/models/config.py
@@ -16,11 +16,9 @@ class GeneralConfig(BaseModel, frozen=True):
     n_knights: int | None = Field(default=None, title="The number of knights. Default is None.")  # noqa
     n_fortune_tellers: int | None = Field(default=None, title="The number of fortune tellers. Default is None.")  # noqa
     output: str | None = Field(default=None, title='The output file. Defaults to None.')  # noqa
-    cli_output_level: ESystemOutputType | str | None = Field(
-        default=None,
-        title=f"The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is None.",  # noqa
-    )
-    system_interface: EInputOutputType | None = Field(default=None, title="The system interface. Default is None.")  # noqa
+    system_output_level: ESystemOutputType | str | None = Field(default=None, title=f"The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is None.")  # noqa
+    system_input_interface: EInputOutputType | None = Field(default=None, title="The system input interface. Default is None.")  # noqa
+    system_output_interface: EInputOutputType | None = Field(default=None, title="The system output interface. Default is None.")  # noqa
     system_formatter: str | None = Field(default=None, title="The system formatter. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
     seed: int | None = Field(default=None, title="The random seed. Defaults to None.")  # noqa
     model: str | None = Field(default=None, title=f"The model to use. Default is None.")  # noqa
@@ -33,7 +31,8 @@ class PlayerConfig(BaseModel, frozen=True):
     name: str = Field(..., title="The name of the player", default_factory=consecutive_string_generator(CUSTOM_PLAYER_PREFIX).__next__)  # noqa
     role: ERole | None = Field(default=None, title="The role of the player")  # noqa
     model: str = Field(default=DEFAULT_MODEL, title=f"The model to use. Default is {DEFAULT_MODEL}.")  # noqa
-    input_output_type: EInputOutputType | None = Field(default=None, title="The input output type of the player")  # noqa
+    player_output_interface: EInputOutputType | None = Field(default=None, title="The output interface of the player")  # noqa
+    player_input_interface: EInputOutputType | None = Field(default=None, title="The input interface of the player")  # noqa
     formatter: str | None = Field(default=None, title="The formatter of the player. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
 
 

--- a/langchain_werewolf/setup.py
+++ b/langchain_werewolf/setup.py
@@ -205,7 +205,7 @@ def _create_echo_runnable_by_player(
                         )
                         | RunnableLambda(lambda dic: MsgModel(**(dic['orig'].model_dump() | {'message': dic['translated_msg']})))  # noqa
                         | RunnableLambda(
-                            (lambda m: player.formatter.format(**m.model_dump()))
+                            (lambda m: player.formatter.format(**m.model_dump()))  # noqa
                             if isinstance(player.formatter, str) else
                             (player.formatter or MsgModel.format)
                         )
@@ -223,7 +223,7 @@ def _create_echo_runnable_by_player(
 
 
 def _create_echo_runnable_by_system(
-    output_func: EInputOutputType,
+    output_func: Callable[[str], None] | EInputOutputType,
     level: ESystemOutputType | str,
     *,
     model: str = DEFAULT_MODEL,

--- a/langchain_werewolf/setup.py
+++ b/langchain_werewolf/setup.py
@@ -204,8 +204,13 @@ def _create_echo_runnable_by_player(
                             ),
                         )
                         | RunnableLambda(lambda dic: MsgModel(**(dic['orig'].model_dump() | {'message': dic['translated_msg']})))  # noqa
+                        | RunnableLambda(
+                            (lambda m: player.formatter.format(**m.model_dump()))
+                            if isinstance(player.formatter, str) else
+                            (player.formatter or MsgModel.format)
+                        )
                         | create_output_runnable(
-                            output_func=player.receive_message,
+                            output_func=player.output.invoke,
                             styler=partial(click.style, fg=color or CLI_PROMPT_COLOR) if color is not None else None,  # noqa
                         )
                     ),

--- a/langchain_werewolf/setup.py
+++ b/langchain_werewolf/setup.py
@@ -147,12 +147,12 @@ def generate_players(
             name=player_cfg.name if player_cfg and player_cfg.name else name_generator.__next__(),  # noqa
             runnable=generate_game_player_runnable(_generate_base_runnable(
                 player_cfg.model if hasattr(player_cfg, 'model') else model,  # type: ignore # noqa
-                player_cfg.input_output_type if hasattr(player_cfg, 'input_output_type') else input_output_type,  # type: ignore # noqa
+                player_cfg.player_input_interface if hasattr(player_cfg, 'input_output_type') else input_output_type,  # type: ignore # noqa
                 seed
             )),
             output=(
-                create_output_runnable(player_cfg.input_output_type)
-                if player_cfg and player_cfg.input_output_type
+                create_output_runnable(player_cfg.player_output_interface)
+                if player_cfg and player_cfg.player_output_interface
                 else None
             ),
             formatter=player_cfg.formatter if player_cfg and player_cfg.formatter else None,  # noqa
@@ -196,7 +196,7 @@ def _create_echo_runnable_by_player(
                                     to_language=language,
                                     chat_llm=_generate_base_runnable(
                                         player_config.model if hasattr(player_config, 'model') else model,  # type: ignore # noqa
-                                        player_config.input_output_type if hasattr(player_config, 'input_output_type') else input_output_type,  # type: ignore # noqa
+                                        player_config.player_output_interface if hasattr(player_config, 'input_output_type') else input_output_type,  # type: ignore # noqa
                                         seed=seed
                                     ),
                                 )

--- a/langchain_werewolf/setup.py
+++ b/langchain_werewolf/setup.py
@@ -176,6 +176,8 @@ def _create_echo_runnable_by_player(
     seed: int = -1,
 ) -> Runnable[StateModel, None]:
     cache = cache or set()  # NOTE: if cache is None, cache does not work
+    if player.output is None:
+        return RunnableLambda(lambda _: None)
     # create runnable
     return (
         RunnableLambda(lambda state: filter_state_according_to_player(player, state))  # noqa

--- a/langchain_werewolf/setup.py
+++ b/langchain_werewolf/setup.py
@@ -197,7 +197,7 @@ def _create_echo_runnable_by_player(
                                     to_language=language,
                                     chat_llm=_generate_base_runnable(
                                         player_config.model if hasattr(player_config, 'model') else model,  # type: ignore # noqa
-                                        player_config.player_output_interface if hasattr(player_config, 'input_output_type') else None,  # type: ignore # noqa
+                                        player_config.player_input_interface if hasattr(player_config, 'input_output_type') else None,  # type: ignore # noqa
                                         seed=seed
                                     ),
                                 )

--- a/langchain_werewolf/setup.py
+++ b/langchain_werewolf/setup.py
@@ -204,7 +204,7 @@ def _create_echo_runnable_by_player(
                         | RunnableLambda(lambda dic: MsgModel(**(dic['orig'].model_dump() | {'message': dic['translated_msg']})))  # noqa
                         | create_output_runnable(
                             output_func=player.receive_message,
-                            styler=partial(click.style, fg=color or CLI_PROMPT_COLOR),  # noqa
+                            styler=partial(click.style, fg=color or CLI_PROMPT_COLOR) if color is not None else None,  # noqa
                         )
                     ),
                 )
@@ -290,7 +290,7 @@ def _create_echo_runnable_by_system(
                                         styler=partial(
                                             click.style,
                                             fg=color.get(name) if isinstance(color, dict) else color,  # noqa
-                                        ),
+                                        ) if color is not None else None,
                                     ),
                                 )
                                 for name in player_names
@@ -301,7 +301,7 @@ def _create_echo_runnable_by_system(
                                 styler=partial(
                                     click.style,
                                     fg=color.get(GAME_MASTER_NAME) if isinstance(color, dict) else color,  # noqa
-                                ),
+                                ) if color is not None else None,
                             ),
                         )
                     ),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,7 @@ def test_main_integration() -> None:
         n_knights=1,
         n_fortune_tellers=1,
         output='',
-        cli_output_level=ESystemOutputType.off,
-        system_interface=EInputOutputType.standard,
+        system_output_level=ESystemOutputType.off,
+        system_output_interface=EInputOutputType.standard,
         seed=-1,
     )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -213,8 +213,6 @@ def test__create_echo_runnable_by_player() -> None:
     _create_echo_runnable_by_player(
         player=player,
         player_config=None,
-        model='cli',
-        input_output_type=EInputOutputType.standard,
     )
 
 
@@ -243,7 +241,7 @@ def test__create_echo_runnable_by_system_with_invalid_level() -> None:
     # assert
     with pytest.raises(ValueError):
         _create_echo_runnable_by_system(
-            kind=EInputOutputType.standard,
+            output_func=EInputOutputType.standard,
             level='invalid',
             player_names=['name'],
         )
@@ -275,8 +273,8 @@ def test_create_echo_runnable(mocker: MockerFixture) -> None:
     ]
     # execute
     create_echo_runnable(
-        input_output_type=EInputOutputType.standard,
-        cli_output_level=ESystemOutputType.all,
+        system_output_interface=EInputOutputType.standard,
+        system_output_level=ESystemOutputType.all,
         players=players,
         players_cfg=[PlayerConfig(role=player.role) for player in players],
     )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -281,6 +281,7 @@ def test__create_echo_runnable_by_player_whether_invoke_method_calls_formatter_a
     mocker: MockerFixture,
 ) -> None:
     # preparation
+    mocker.patch('langchain_werewolf.setup._generate_base_runnable', mocker.Mock(return_value=RunnableLambda(str)))  # noqa
     output_mock = mocker.Mock()
     player = BaseGamePlayer.instantiate(
         role=ERole.Villager,

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -75,15 +75,15 @@ STATE4TEST = StateModel(
             ] + [
                 IdentifiedModel[MsgModel](value=MsgModel(
                     name=name,
-                    message=f'Hello, everyone!',
+                    message='Hello, everyone!',
                     participants=frozenset(set(PLAYER_NAMES4TEST) | {GAME_MASTER_NAME}),  # noqa
                 ))
                 for name in PLAYER_NAMES4TEST
             ],
         )
     },
-    alive_players_names=PLAYER_NAMES4TEST,
-    safe_players_names=[],
+    alive_players_names=list(PLAYER_NAMES4TEST),
+    safe_players_names=set(),
     current_speaker=None,
     n_chat_remaining=0,
     daytime_vote_result_history=[],
@@ -281,8 +281,6 @@ def test__create_echo_runnable_by_player_whether_invoke_method_calls_formatter_a
     mocker: MockerFixture,
 ) -> None:
     # preparation
-    player_name: str = PLAYER_NAMES4TEST[0]
-    formatter = MsgModel.format
     output_mock = mocker.Mock()
     player = BaseGamePlayer.instantiate(
         role=ERole.Villager,
@@ -292,11 +290,20 @@ def test__create_echo_runnable_by_player_whether_invoke_method_calls_formatter_a
         formatter=formatter,
     )
     expected = sorted([
-        mocker.call(formatter(msg.value))
+        mocker.call(
+            formatter(msg.value)
+            if callable(formatter)
+            else (
+                formatter.format(**msg.value.model_dump())
+                if isinstance(formatter, str)
+                else MsgModel.format(msg.value)
+            )
+        )
         for k, chat_history in STATE4TEST.chat_state.items()
         if player_name in k
         for msg in chat_history.messages
     ], key=lambda msg: msg.timestamp)
+    assert expected  # check not empty
     # execute
     echo_runnable = _create_echo_runnable_by_player(
         player=player,
@@ -314,7 +321,7 @@ def test__create_echo_runnable_by_player_whether_invoke_method_calls_formatter_a
     [
         (level, formatter, expected_messages)
         for level, expected_messages in zip(
-                [
+            [
                 ESystemOutputType.off,
                 ESystemOutputType.all,
                 ESystemOutputType.public,
@@ -331,7 +338,7 @@ def test__create_echo_runnable_by_player_whether_invoke_method_calls_formatter_a
                 sorted([
                     msg.value
                     for k, chat_history in STATE4TEST.chat_state.items()
-                    if k == frozenset({GAME_MASTER_NAME} | set(PLAYER_NAMES4TEST))
+                    if k == frozenset({GAME_MASTER_NAME} | set(PLAYER_NAMES4TEST))  # noqa
                     for msg in chat_history.messages
                 ], key=lambda msg: msg.timestamp),
                 sorted([
@@ -375,7 +382,7 @@ def test__create_echo_runnable_by_system_whether_invoke_method_calls_formatter_a
         # create spy
         formatter_spy = mocker.Mock(side_effect=formatter.format)
         formatter = mocker.Mock(spec=str)
-        formatter.format = formatter_spy
+        formatter.format = formatter_spy  # type: ignore
     elif callable(formatter):
         # create expected
         expected_formatter_calls = [mocker.call(msg) for msg in expected_messages]  # noqa


### PR DESCRIPTION
This pull request refactors the `setup.py` and `config.py` files to add support for customizable input and output interfaces for both the system and players. It allows for the use of callable types in the input/output interfaces and fixes the color handling in the `echo_runnable` functions. Additionally, it adds a handler for `noneplayer.output` and includes detailed tests for `_create_echo_runnable_by_xxxxxx`.