### PR TITLE
Update system_formatter and player formatter to accept a callable function

### DIFF
--- a/langchain_werewolf/models/config.py
+++ b/langchain_werewolf/models/config.py
@@ -21,7 +21,7 @@ class GeneralConfig(BaseModel, frozen=True):
     system_output_level: ESystemOutputType | str | None = Field(default=None, title=f"The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is None.")  # noqa
     system_output_interface: Callable[[str], None] | EInputOutputType | None = Field(default=None, title="The system output interface. Default is None.")  # noqa
     system_input_interface: Callable[[str], Any] | EInputOutputType | None = Field(default=None, title="The system input interface. Default is None.")  # noqa
-    system_formatter: str | None = Field(default=None, title="The system formatter. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
+    system_formatter: Callable[[MsgModel], str] | str | None = Field(default=None, title="The system formatter. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
     system_font_color: str | None = Field(default=None, title="The system font color. Default is None.")  # noqa
     player_font_colors: Iterable | str | None = Field(default=None, title="The player font colors. Default is None.")  # noqa
     seed: int | None = Field(default=None, title="The random seed. Defaults to None.")  # noqa
@@ -38,7 +38,7 @@ class PlayerConfig(BaseModel, frozen=True):
     language: ELanguage | None = Field(default=None, title="The language of the player")  # noqa
     player_output_interface: Callable[[str], None] | EInputOutputType | None = Field(default=None, title="The output interface of the player")  # noqa
     player_input_interface: Callable[[str], Any] | EInputOutputType | None = Field(default=None, title="The input interface of the player")  # noqa
-    formatter: str | None = Field(default=None, title="The formatter of the player. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
+    formatter: Callable[[MsgModel], str] | str | None = Field(default=None, title="The formatter of the player. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
 
 
 class GameConfig(BaseModel, frozen=True):


### PR DESCRIPTION
This pull request updates the `system_formatter` and `player_formatter` in the `GeneralConfig` and `PlayerConfig` classes to accept a callable function instead of a string. This allows for more flexibility in formatting the output of the system and player.