### PR TITLE
remove pics change detection from automatically-update-readme.yml

### DIFF
--- a/.github/workflows/automatically-update-readme.yml
+++ b/.github/workflows/automatically-update-readme.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check if README.md has changed
         id: check_changes
         run: |
-          if [[ -n $(git status --porcelain README.md pics) ]]; then
+          if [[ -n $(git status --porcelain README.md) ]]; then
             echo "README.md has changed."
             echo "changes_detected=true" >> "$GITHUB_ENV"
           else


### PR DESCRIPTION
This PR solves a problem that automatically-update-readme.yml creates many PRs because it detects non essential changes of  pics.