### PR TITLE
Fix generate_base_runnable in setup.py to make a custom input interface available for each player

### DIFF
--- a/langchain_werewolf/const.py
+++ b/langchain_werewolf/const.py
@@ -37,7 +37,6 @@ CUSTOM_PLAYER_PREFIX: str = 'CustomPlayer'
 # llm
 DEFAULT_MODEL: str = 'gpt-4o-mini'
 MODEL_SERVICE_MAP: dict[str, EChatService] = {
-    'cli': EChatService.CLI,
     'gpt-3.5-turbo': EChatService.OpenAI,
     'gpt-4': EChatService.OpenAI,
     'gpt-4-turbo': EChatService.OpenAI,

--- a/langchain_werewolf/enums.py
+++ b/langchain_werewolf/enums.py
@@ -43,7 +43,6 @@ class ESideVictoryCondition(Enum):
 
 
 class EChatService(Enum):
-    CLI: str = 'cli'
     OpenAI: str = 'openai'
     Google: str = 'google'
     Groq: str = 'groq'


### PR DESCRIPTION
This pull request fixes the generate_base_runnable function in setup.py to ensure that a custom input interface is available for each player. Previously, the function did not properly handle the case when the input_func parameter was not None and the model parameter was None. This caused an error to be raised. With this fix, the function now correctly generates a BaseChatModel instance or a Runnable instance based on the provided parameters. Additionally, a warning message is logged if an invalid pair of model and input_func is provided, and the function falls back to using a chat model with the DEFAULT_MODEL.