### PR TITLE
Clean game messages

### DIFF
--- a/langchain_werewolf/enums.py
+++ b/langchain_werewolf/enums.py
@@ -33,8 +33,8 @@ class ESide(Enum):
 
 
 class EResult(Enum):
-    VillagersWin: str = 'VillagersWin'
-    WerewolvesWin: str = 'WerewolvesWin'
+    VillagersWin: str = 'Villagers Win'
+    WerewolvesWin: str = 'Werewolves Win'
 
 
 class ESideVictoryCondition(Enum):

--- a/langchain_werewolf/game/check_result.py
+++ b/langchain_werewolf/game/check_result.py
@@ -21,7 +21,7 @@ RESULT_ANNOUNCE_NODE_NAME: str = 'announce_result'
 REVEAL_ROLES_NODE_NAME: str = 'reveal_roles'
 
 GAME_RESULT_MESSAGE_TEMPLATE: str = 'The game has ended: {result}'
-PLAYER_ROLE_MESSAGE_TEMPLATE: str = '- {name} is {role} (State: {state})'
+PLAYER_ROLE_MESSAGE_TEMPLATE: str = '- The role of {name} is {role} (State: {state})'
 REVEAL_ALL_PLAYER_ROLES_MESSAGE_TEMPLATE: str = '''The roles of the players are as follows:
 {roles}
 '''  # noqa
@@ -79,7 +79,7 @@ def create_check_victory_condition_subgraph(
         lambda state: create_dict_to_record_chat(
             sender=GAME_MASTER_NAME,
             participants=[GAME_MASTER_NAME]+[p.name for p in players],
-            message=GAME_RESULT_MESSAGE_TEMPLATE.format(result=state.result),  # noqa
+            message=GAME_RESULT_MESSAGE_TEMPLATE.format(result=state.result.value),  # noqa
         ),
     )
     workflow.add_node(
@@ -91,7 +91,7 @@ def create_check_victory_condition_subgraph(
                 roles='\n'.join([
                     PLAYER_ROLE_MESSAGE_TEMPLATE.format(
                         name=player.name,
-                        role=player.role,
+                        role=player.role.value,
                         state=(
                             'Alive'
                             if player.name in state.alive_players_names else

--- a/langchain_werewolf/game/check_result.py
+++ b/langchain_werewolf/game/check_result.py
@@ -21,7 +21,7 @@ RESULT_ANNOUNCE_NODE_NAME: str = 'announce_result'
 REVEAL_ROLES_NODE_NAME: str = 'reveal_roles'
 
 GAME_RESULT_MESSAGE_TEMPLATE: str = 'The game has ended: {result}'
-PLAYER_ROLE_MESSAGE_TEMPLATE: str = '- The role of {name} is {role} (State: {state})'
+PLAYER_ROLE_MESSAGE_TEMPLATE: str = '- The role of {name} is {role} (State: {state})'  # noqa
 REVEAL_ALL_PLAYER_ROLES_MESSAGE_TEMPLATE: str = '''The roles of the players are as follows:
 {roles}
 '''  # noqa

--- a/langchain_werewolf/game/night_action.py
+++ b/langchain_werewolf/game/night_action.py
@@ -55,7 +55,7 @@ def _master_ask_player_to_act_in_night(
         participants=[player.name, GAME_MASTER_NAME],
         message=generate_prompt(
             GeneratePromptInputForNightAction(
-                role=player.role,
+                role=player.role.value,
                 night_action=player.night_action or '',
                 question_to_decide_night_action=player.question_to_decide_night_action or '',  # noqa
                 alive_players_names=state.alive_players_names,

--- a/langchain_werewolf/game/night_action.py
+++ b/langchain_werewolf/game/night_action.py
@@ -39,7 +39,7 @@ Werewolves may exclude one player from the game.
 
 
 class GeneratePromptInputForNightAction(BaseModel):
-    role: ERole = Field(..., title="the role of the player")
+    role: str = Field(..., title="the role of the player")
     night_action: str = Field(..., title="the night action of the player")  # noqa
     question_to_decide_night_action: str = Field(..., title="the question to decide the night action of the player")  # noqa
     alive_players_names: list[str] = Field(..., title="the names of the alive players")  # noqa

--- a/langchain_werewolf/game/setup.py
+++ b/langchain_werewolf/game/setup.py
@@ -77,7 +77,7 @@ def _announce_game_rule(
         sender=GAME_MASTER_NAME,
         participants=[GAME_MASTER_NAME]+[player.name for player in players],
         message=game_rule_template.format(
-            n_roles=len(players),
+            n_roles=len(roles_explanation),
             roles='\n'.join([
                 f'{idx+1}. {role_exp}'
                 for idx, role_exp in enumerate(roles_explanation)

--- a/tests/game/test_night_action.py
+++ b/tests/game/test_night_action.py
@@ -36,7 +36,7 @@ def test__master_ask_player_to_act_in_night() -> None:
     assert actual['chat_state'][frozenset([player.name, GAME_MASTER_NAME])]
     assert actual['chat_state'][frozenset([player.name, GAME_MASTER_NAME])].messages  # noqa
     assert actual['chat_state'][frozenset([player.name, GAME_MASTER_NAME])].messages[0].value.name == GAME_MASTER_NAME  # noqa
-    assert actual['chat_state'][frozenset([player.name, GAME_MASTER_NAME])].messages[0].value.message == generate_prompt(GeneratePromptInputForNightAction(role=player.role, night_action=player.night_action, question_to_decide_night_action=player.question_to_decide_night_action, alive_players_names=state.alive_players_names))  # type: ignore # noqa
+    assert actual['chat_state'][frozenset([player.name, GAME_MASTER_NAME])].messages[0].value.message == generate_prompt(GeneratePromptInputForNightAction(role=player.role.value, night_action=player.night_action, question_to_decide_night_action=player.question_to_decide_night_action, alive_players_names=state.alive_players_names))  # type: ignore # noqa
     assert actual['chat_state'][frozenset([player.name, GAME_MASTER_NAME])].messages[0].value.participants == frozenset([player.name, GAME_MASTER_NAME])  # noqa
 
 

--- a/tests/game/test_setup.py
+++ b/tests/game/test_setup.py
@@ -24,12 +24,13 @@ def test__announce_game_rule() -> None:
     names = frozenset([GAME_MASTER_NAME]+[player.name for player in players])
     state = StateModel(alive_players_names=[player.name for player in players])  # noqa
     expected_message = GAME_RULE_TEMPLATE.format(
+        n_roles=len({p.role for p in players}),
         roles='\n'.join([
             f'{idx+1}. {role_exp}'
             for idx, role_exp in enumerate({
                 ROLE_EXPLANATION_TEMPLATE.format(
-                    role=player.role,
-                    side=player.side,
+                    role=player.role.value,
+                    side=player.side.value,
                     victory_condition=player.victory_condition,
                     night_action=player.night_action,
                 )
@@ -64,8 +65,8 @@ def test__announce_role(player: BaseGamePlayer) -> None:
     # preparation
     state = StateModel(alive_players_names=[player.name])
     expected_message = ROLE_ANNOUNCE_TEMPLATE.format(
-        role=player.role,
-        side=player.side,
+        role=player.role.value,
+        side=player.side.value,
         victory_condition=player.victory_condition,
         night_action=player.night_action,
     )


### PR DESCRIPTION
This pull request cleans up the game messages by making the following changes:

- Renamed the `EResult` enum values to have spaces between words for better readability.

- Updated the `PLAYER_ROLE_MESSAGE_TEMPLATE` to include the phrase "The role of" before the player's name for clarity.

- Updated the `GAME_RESULT_MESSAGE_TEMPLATE` to use the `value` attribute of the `EResult` enum for the result message.

- Updated the `create_check_victory_condition_subgraph` function to use the `value` attribute of the `EResult` enum for the game result message.

- Updated the `create_check_victory_condition_subgraph` function to use the `value` attribute of the `ERole` enum for the player role message.

- Updated the `_master_ask_player_to_act_in_night` function to use the `value` attribute of the `ERole` enum for the player role in the night action prompt.

- Updated the `WELCOME_TO_GAME_MESSAGE` to remove extra spaces for better formatting.

- Updated the `GAME_RULE_TEMPLATE` to include the number of roles in the game and to use the `value` attribute of the `ERole` and `ESide` enums for the role explanation.

- Updated the `_announce_role` function to use the `value` attribute of the `ERole` and `ESide` enums for the role announcement.

- Updated the `create_game_preparation_graph` function to remove extra spaces around the `WELCOME_TO_GAME_MESSAGE` for better formatting.

- Updated the `test__announce_game_rule` and `test__announce_role` functions to use the `value` attribute of the `ERole` and `ESide` enums for the expected messages.