### PR TITLE
Skip pytest workflow for Python 3.10

### DIFF
--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Remove Python 3.10 from the pytest workflow matrix to streamline testing with supported versions only.

This PR is a patch for #38 