### PR TITLE
fix: include player side in role announcement message

### DIFF
--- a/langchain_werewolf/game/check_result.py
+++ b/langchain_werewolf/game/check_result.py
@@ -6,6 +6,7 @@ from ..const import GAME_MASTER_NAME
 from ..enums import EResult
 from ..game_players import (
     BaseGamePlayerRole,
+    is_player_with_side,
     is_werewolf_role,
 )
 from ..models.state import (
@@ -24,7 +25,7 @@ RESULT_ANNOUNCE_NODE_NAME: str = 'announce_result'
 REVEAL_ROLES_NODE_NAME: str = 'reveal_roles'
 
 GAME_RESULT_MESSAGE_TEMPLATE: str = 'The game has ended: {result}'
-PLAYER_ROLE_MESSAGE_TEMPLATE: str = '- The role of {name} is {role} (State: {state})'  # noqa
+PLAYER_ROLE_MESSAGE_TEMPLATE: str = '- The role of {name} is {role}({side}) (State: {state})'  # noqa
 REVEAL_ALL_PLAYER_ROLES_MESSAGE_TEMPLATE: str = '''The roles of the players are as follows:
 {roles}
 '''  # noqa
@@ -103,7 +104,8 @@ def create_check_victory_condition_subgraph(
                                 if player.name in {v.value for v in state.daytime_vote_result_history} else  # noqa
                                 f'Day {list(v.value for v in state.nighttime_vote_result_history).index(player.name)+1} nighttime'  # noqa
                             )
-                        ),  # noqa
+                        ),
+                        side=is_player_with_side(player) and player.side,
                     )
                     for player in players
                 ])

--- a/langchain_werewolf/game/check_result.py
+++ b/langchain_werewolf/game/check_result.py
@@ -25,7 +25,7 @@ RESULT_ANNOUNCE_NODE_NAME: str = 'announce_result'
 REVEAL_ROLES_NODE_NAME: str = 'reveal_roles'
 
 GAME_RESULT_MESSAGE_TEMPLATE: str = 'The game has ended: {result}'
-PLAYER_ROLE_MESSAGE_TEMPLATE: str = '- The role of {name} is {role}({side}) (State: {state})'  # noqa
+PLAYER_ROLE_MESSAGE_TEMPLATE: str = '- The role of {name} is {role} ({side}) (State: {state})'  # noqa
 REVEAL_ALL_PLAYER_ROLES_MESSAGE_TEMPLATE: str = '''The roles of the players are as follows:
 {roles}
 '''  # noqa


### PR DESCRIPTION

## ✨ What’s New
Display each player’s **side (faction)** in the role-reveal message shown at the end of the game.  
This makes it easier to verify victory conditions, since roles alone don’t always indicate which team a player belonged to.

---

## 🔍 Changes

| Type | File / Constant | Description |
|------|-----------------|-------------|
| **Add** | `..game_players.is_player_with_side` import | Needed to check whether a player exposes a `side` attribute |
| **Update** | `PLAYER_ROLE_MESSAGE_TEMPLATE` | Changed to `- The role of {name} is {role}({side}) (State: {state})` so the side is shown in parentheses |
| **Logic** | `create_check_victory_condition_subgraph` | Pass `side=is_player_with_side(player) and player.side` when building result nodes |

---

## 🖼️ Output Example

<details>
<summary>Before</summary>

```
- The role of Alice is werewolf (State: Alive)
- The role of Bob is villager (State: Excluded in Day 1 daytime)
```

</details>

<details>
<summary>After</summary>

```
- The role of Alice is werewolf(WerewolfSide) (State: Alive)
- The role of Bob is villager(VillagerSide) (State: Excluded in Day 1 daytime)
```
</details>

---

## ✅ Impact
* **No game-logic changes** — only the message text is modified.  
* Update any unit tests that assert on the exact message string.

---

## 📝 How to Test

1. Run a game to completion with any configuration.  
2. At the end-of-game summary, verify that each line now shows the side in parentheses, e.g. `(VillagerSide)` or `(WerewolfSide)`.

---

## Related Issues  
N/A (add links if applicable)
