### PR TITLE
refactor: Support Human Participation & Refactor I/O Handling

### DIFF
--- a/examples/config/config_human_participates_example1.json
+++ b/examples/config/config_human_participates_example1.json
@@ -22,7 +22,8 @@
         {
             "name": "Me",
             "player_input_interface": "click",
-            "player_output_interface": "click"
+            "player_output_interface": "click",
+            "language": "Japanese"
         }
     ]
 }

--- a/examples/config/config_human_participates_example1.json
+++ b/examples/config/config_human_participates_example1.json
@@ -1,0 +1,28 @@
+{
+    "general": {
+        "n_players": 5,
+        "n_players_by_role": {
+            "werewolf": 2,
+            "fortuneteller": 1,
+            "knight": 2
+        },
+        "system_output_interface": "none"
+    },
+    "game": {
+        "daytime_chat_kwargs": {
+            "n_turns_per_day": 2,
+            "select_speaker": "round_robin"
+        },
+        "nighttime_chat_kwargs": {
+            "n_turns_per_day": 2,
+            "select_speaker": "random"
+        }
+    },
+    "players": [
+        {
+            "name": "Me",
+            "player_input_interface": "click",
+            "player_output_interface": "click"
+        }
+    ]
+}

--- a/langchain_werewolf/enums.py
+++ b/langchain_werewolf/enums.py
@@ -38,6 +38,7 @@ class ESystemOutputType(Enum):
 
 
 class EInputOutputType(Enum):
+    none = 'none'
     standard = 'standard'
     click = 'click'
 

--- a/langchain_werewolf/io.py
+++ b/langchain_werewolf/io.py
@@ -26,11 +26,11 @@ _input_map: dict[EInputOutputType, Callable[[str], Any]] = {
     EInputOutputType.none: lambda _: None,
     EInputOutputType.standard: delay_deco(attach_prefix_to_prompt(input), seconds=2),  # noqa
     EInputOutputType.click: delay_deco(attach_prefix_to_prompt(click.prompt), seconds=2),  # noqa
-    # FIXME: The use of `delay_deco` here introduces a delay to avoid overlapping output and input prompts,
-    # which can cause confusion in interactive sessions. However, this is a temporary workaround.
-    # A long-term solution could involve redesigning the input/output handling to ensure proper synchronization
-    # without relying on arbitrary delays. Consider exploring event-driven approaches or threading mechanisms
-    # to manage prompt timing more effectively.  # noqa
+    # FIXME: The use of `delay_deco` here introduces a delay to avoid overlapping output and input prompts,  # noqa
+    # which can cause confusion in interactive sessions. However, this is a temporary workaround.  # noqa
+    # A long-term solution could involve redesigning the input/output handling to ensure proper synchronization  # noqa
+    # without relying on arbitrary delays. Consider exploring event-driven approaches or threading mechanisms  # noqa
+    # to manage prompt timing more effectively.
 }
 
 _output_map: dict[EInputOutputType, Callable[[Any], None]] = {

--- a/langchain_werewolf/io.py
+++ b/langchain_werewolf/io.py
@@ -24,8 +24,8 @@ def attach_prefix_to_prompt(
 
 _input_map: dict[EInputOutputType, Callable[[str], Any]] = {
     EInputOutputType.none: lambda _: None,
-    EInputOutputType.standard: delay_deco(attach_prefix_to_prompt(input), seconds=2),
-    EInputOutputType.click: delay_deco(attach_prefix_to_prompt(click.prompt), seconds=2),
+    EInputOutputType.standard: delay_deco(attach_prefix_to_prompt(input), seconds=2),  # noqa
+    EInputOutputType.click: delay_deco(attach_prefix_to_prompt(click.prompt), seconds=2),  # noqa
     # FIXME: fix the above `delay_deco`. This is a patch to avoid the conflict between the output and the input prompt.  # noqa
 }
 

--- a/langchain_werewolf/io.py
+++ b/langchain_werewolf/io.py
@@ -9,12 +9,26 @@ from langchain_core.runnables import (
 from .enums import EInputOutputType
 
 
+def attach_prefix_to_prompt(
+    input_func: Callable[[str], Any],
+    prefix: str = ">>> ",
+) -> Callable[[str], Any]:
+
+    def wrapped_input_func(prompt: str, *args, **kwargs) -> Any:
+        prompt = f"{prefix} {prompt}"
+        return input_func(prompt, *args, **kwargs)
+
+    return wrapped_input_func
+
+
 _input_map: dict[EInputOutputType, Callable[[str], Any]] = {
-    EInputOutputType.standard: input,
-    EInputOutputType.click: click.prompt,
+    EInputOutputType.none: lambda _: None,
+    EInputOutputType.standard: attach_prefix_to_prompt(input),
+    EInputOutputType.click: attach_prefix_to_prompt(click.prompt),
 }
 
 _output_map: dict[EInputOutputType, Callable[[Any], None]] = {
+    EInputOutputType.none: lambda _: None,
     EInputOutputType.standard: print,
     EInputOutputType.click: click.echo,
 }

--- a/langchain_werewolf/io.py
+++ b/langchain_werewolf/io.py
@@ -7,11 +7,12 @@ from langchain_core.runnables import (
     RunnablePassthrough,
 )
 from .enums import EInputOutputType
+from .utils import delay_deco
 
 
 def attach_prefix_to_prompt(
     input_func: Callable[[str], Any],
-    prefix: str = ">>> ",
+    prefix: str = "",
 ) -> Callable[[str], Any]:
 
     def wrapped_input_func(prompt: str, *args, **kwargs) -> Any:
@@ -23,8 +24,9 @@ def attach_prefix_to_prompt(
 
 _input_map: dict[EInputOutputType, Callable[[str], Any]] = {
     EInputOutputType.none: lambda _: None,
-    EInputOutputType.standard: attach_prefix_to_prompt(input),
-    EInputOutputType.click: attach_prefix_to_prompt(click.prompt),
+    EInputOutputType.standard: delay_deco(attach_prefix_to_prompt(input), seconds=2),
+    EInputOutputType.click: delay_deco(attach_prefix_to_prompt(click.prompt), seconds=2),
+    # FIXME: fix the above `delay_deco`. This is a patch to avoid the conflict between the output and the input prompt.  # noqa
 }
 
 _output_map: dict[EInputOutputType, Callable[[Any], None]] = {

--- a/langchain_werewolf/main.py
+++ b/langchain_werewolf/main.py
@@ -1,7 +1,7 @@
 from itertools import cycle
 import logging
 import random
-from typing import Any, Callable, Iterable
+from typing import Callable, Iterable
 import click
 from dotenv import load_dotenv
 from langchain.globals import set_verbose, set_debug
@@ -35,7 +35,6 @@ DEFAULT_CONFIG = Config(
         output='',
         system_output_level=ESystemOutputType.all,
         system_output_interface=EInputOutputType.standard,
-        system_input_interface=EInputOutputType.standard,
         system_language=BASE_LANGUAGE,
         system_formatter=None,
         system_font_color=CLI_PROMPT_COLOR,
@@ -56,7 +55,6 @@ def main(
     output: str = DEFAULT_GENERAL_CONFIG.output,  # type: ignore # noqa
     system_output_level:  ESystemOutputType | str = DEFAULT_GENERAL_CONFIG.system_output_level,  # type: ignore # noqa
     system_output_interface: Callable[[str], None] | EInputOutputType = DEFAULT_GENERAL_CONFIG.system_output_interface,  # type: ignore # noqa
-    system_input_interface: Callable[[str], Any] | EInputOutputType = DEFAULT_GENERAL_CONFIG.system_input_interface,  # type: ignore # noqa
     system_language: ELanguage | None = DEFAULT_GENERAL_CONFIG.system_language,  # type: ignore # noqa
     system_formatter: str | None = DEFAULT_GENERAL_CONFIG.system_formatter,  # type: ignore # noqa
     system_font_color: str | None = DEFAULT_GENERAL_CONFIG.system_font_color,  # type: ignore # noqa
@@ -89,7 +87,6 @@ def main(
             n_players_by_role=config.general.n_players_by_role if (config is not None and config.general.n_players_by_role is not None) else n_players_by_role,  # noqa
             output=config.general.output if (config is not None and config.general.output is not None) else output,  # noqa
             system_output_level=config.general.system_output_level if (config is not None and config.general.system_output_level is not None) else system_output_level,  # noqa
-            system_input_interface=config.general.system_input_interface if (config is not None and config.general.system_input_interface is not None) else system_input_interface,  # noqa
             system_output_interface=config.general.system_output_interface if (config is not None and config.general.system_output_interface is not None) else system_output_interface,  # noqa
             system_language=config.general.system_language if (config is not None and config.general.system_language is not None) else system_language,  # noqa
             system_formatter=config.general.system_formatter if (config is not None and config.general.system_formatter is not None) else system_formatter,  # noqa
@@ -118,7 +115,6 @@ def main(
         config_used.general.n_players_by_role,
         model=config_used.general.model,
         seed=config_used.general.seed,  # type: ignore
-        player_input_interface=config_used.general.system_input_interface,  # type: ignore # noqa
         custom_players=config_used.players,
     )
 
@@ -181,7 +177,6 @@ def attach_n_players_by_role_options(
 @click.option('-o', '--output', default=DEFAULT_GENERAL_CONFIG.output, help=f'The output file. Defaults to "{DEFAULT_GENERAL_CONFIG.output}".')  # noqa
 @click.option('-l', '--system-output-level', default=DEFAULT_GENERAL_CONFIG.system_output_level.name if isinstance(DEFAULT_GENERAL_CONFIG.system_output_level, ESystemOutputType) else DEFAULT_GENERAL_CONFIG.system_output_level, help=f'The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is All.')  # noqa
 @click.option('--system-output-interface', default=DEFAULT_GENERAL_CONFIG.system_output_interface.name if isinstance(DEFAULT_GENERAL_CONFIG.system_output_interface, EInputOutputType) else DEFAULT_GENERAL_CONFIG.system_output_interface, help=f'The system interface. Default is {DEFAULT_GENERAL_CONFIG.system_output_interface}.')  # noqa
-@click.option('--system-input-interface', default=DEFAULT_GENERAL_CONFIG.system_input_interface.name if isinstance(DEFAULT_GENERAL_CONFIG.system_input_interface, EInputOutputType) else DEFAULT_GENERAL_CONFIG.system_input_interface, help=f'The system interface. Default is {DEFAULT_GENERAL_CONFIG.system_input_interface}.')  # noqa
 @click.option('--system-formatter', default=DEFAULT_GENERAL_CONFIG.system_formatter, help=f'The system formatter. The format should not include anything other than ' + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()) + '.')  # noqa
 @click.option('-c', '--config', default='', help='The configuration file. Defaults to "". Note that you can specify CLI arguments in this config file but the config file overwrite the CLI arguments.')  # noqa
 @click.option('--seed', default=DEFAULT_GENERAL_CONFIG.seed, help=f'The random seed. Defaults to {DEFAULT_GENERAL_CONFIG.seed}.')  # noqa
@@ -195,7 +190,6 @@ def cli(
     output: str = DEFAULT_GENERAL_CONFIG.output,  # type: ignore # noqa
     system_output_level:  str = DEFAULT_GENERAL_CONFIG.system_output_level.name,  # type: ignore # noqa
     system_output_interface: str = DEFAULT_GENERAL_CONFIG.system_output_interface.name,  # type: ignore # noqa
-    system_input_interface: str = DEFAULT_GENERAL_CONFIG.system_input_interface.name,  # type: ignore # noqa
     system_formatter: str = DEFAULT_GENERAL_CONFIG.system_formatter,  # type: ignore # noqa
     config: str = '',  # type: ignore # noqa
     seed: int = DEFAULT_GENERAL_CONFIG.seed,  # type: ignore # noqa
@@ -218,7 +212,6 @@ def cli(
         output=output,
         system_output_level=system_output_level,
         system_output_interface=system_output_interface,  # type: ignore
-        system_input_interface=EInputOutputType(system_input_interface),
         system_formatter=system_formatter,
         config=config,
         seed=seed,

--- a/langchain_werewolf/models/config.py
+++ b/langchain_werewolf/models/config.py
@@ -18,7 +18,6 @@ class GeneralConfig(BaseModel, frozen=True):
     output: str | None = Field(default=None, title='The output file. Defaults to None.')  # noqa
     system_output_level: ESystemOutputType | str | None = Field(default=None, title=f"The output type of the CLI. {list(ESystemOutputType.__members__.keys())} and player names are valid. Default is None.")  # noqa
     system_output_interface: Callable[[str], None] | EInputOutputType | None = Field(default=None, title="The system output interface. Default is None.")  # noqa
-    system_input_interface: Callable[[str], Any] | EInputOutputType | None = Field(default=None, title="The system input interface. Default is None.")  # noqa
     system_language: ELanguage | None = Field(default=None, title="The system language. Default is None.")  # noqa
     system_formatter: Callable[[MsgModel], str] | str | None = Field(default=None, title="The system formatter. The format should not include anything other than " + ', '.join('"{'+k+'}"' for k in MsgModel.model_fields.keys()))  # noqa
     system_font_color: str | None = Field(default=None, title="The system font color. Default is None.")  # noqa

--- a/langchain_werewolf/utils.py
+++ b/langchain_werewolf/utils.py
@@ -152,14 +152,18 @@ def delay_deco(
     """A decorator to delay the execution of a function
 
     Args:
-        func (Callable[P, T] | None, optional): the function to be decorated. Defaults to None.
-        seconds (float, optional): the delay in seconds. Defaults to 1.
+        func (Callable[P, T] | None, optional):
+            the function to be decorated. Defaults to None.
+        seconds (float, optional):
+            the delay in seconds. Defaults to 1.
 
     Returns:
-        Callable[[Callable[P, T]], Callable[P, T]] | Callable[P, T]: the decorated function
+        Callable[[Callable[P, T]], Callable[P, T]] | Callable[P, T]:
+            the decorated function
 
     Notes:
-        - If `func` is None, a deorator is returned. Otherwise, the decorated function is returned.
+        - If `func` is None, a deorator is returned.
+          Otherwise, the decorated function is returned.
     """
 
     if func is None:

--- a/langchain_werewolf/utils.py
+++ b/langchain_werewolf/utils.py
@@ -162,7 +162,7 @@ def delay_deco(
             the decorated function
 
     Notes:
-        - If `func` is None, a deorator is returned.
+        - If `func` is None, a decorator is returned.
           Otherwise, the decorated function is returned.
     """
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -308,7 +308,6 @@ def test_generate_players(mocker: MockerFixture) -> None:
         n_players,
         n_players_by_role,
         seed=0,
-        player_input_interface=EInputOutputType.standard,
         custom_players=custom_players,
     )
     assert len(actual) == n_players
@@ -344,7 +343,6 @@ def test_generate_players_with_custom_input_interface(mocker: MockerFixture) -> 
         n_players,
         n_players_by_role,
         seed=0,
-        player_input_interface=None,
         custom_players=custom_players,
     )
     # assert

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -395,10 +395,7 @@ def test__create_echo_runnable_by_player_whether_invoke_method_calls_formatter_a
     ], key=lambda msg: msg.timestamp)
     assert expected  # check not empty
     # execute
-    echo_runnable = _create_echo_runnable_by_player(
-        player=player,
-        color=None,
-    )
+    echo_runnable = _create_echo_runnable_by_player(player=player)
     echo_runnable.invoke(STATE4TEST)
     # assert
     output_mock.assert_has_calls(expected)


### PR DESCRIPTION
# PR: Support Human Participation & Refactor I/O Handling

## Overview
This pull request introduces **human‐player participation** and streamlines the input/output interface logic across the project.

Key points:

* **New example config** (`examples/config/config_human_participates_example1.json`) that lets a human player join the game via **Click**‐based I/O.  
* Added **`none`** option to `EInputOutputType`, enabling silent (headless) runs.  
* Removed global **`system_input_interface`**—fewer CLI flags and cleaner config.  
* Introduced **`delay_deco`** utility to prevent prompt/echo collisions by delaying user input.  
* Refactored player generation, runnable creation, and echo logic for simpler priorities and fewer parameters.  
* Updated tests to reflect the new APIs and behaviour.

---

## What’s Changed
| Area | Change |
|------|--------|
| **Examples** | Added *config_human_participates_example1.json* demonstrating a 5-player game where *“Me”* participates. |
| **Enums** | Added `none` to `EInputOutputType`. |
| **I/O Layer** | `attach_prefix_to_prompt` prefixes prompts; maps now support `none` and wrap `standard` / `click` with `delay_deco`. |
| **CLI** | Removed `--system-input-interface` flag; related plumbing deleted. |
| **Config Model** | Dropped `system_input_interface` field from `GeneralConfig`. |
| **Player Setup** | `_generate_base_runnable` now prioritises an explicit `input_func`; `generate_players` stops propagating a global input interface. |
| **Echo Logic** | Colour handling removed; messages now pass through `player.receive_message`. |
| **Utilities** | New fully-typed `delay_deco` decorator (supports both direct and higher-order usage). |
| **Tests** | Fixtures updated; removed obsolete parameter assertions. |

---

## Example Config (excerpt)
```json
{
  "general": {
    "n_players": 5,
    "n_players_by_role": {
      "werewolf": 2,
      "fortuneteller": 1,
      "knight": 2
    },
    "system_output_interface": "none"
  },
  "players": [
    {
      "name": "Me",
      "player_input_interface": "click",
      "player_output_interface": "click",
      "language": "Japanese"
    }
  ]
}
```

---

## Breaking Changes
1. **`--system-input-interface` CLI flag is removed.**  
   Update scripts and CI commands accordingly.
2. **`GeneralConfig.system_input_interface` is deleted.**  
   Remove this key from existing JSON configs.

---

## Migration Guide
* **Silent runs:**  
  Use `"system_output_interface": "none"` in config files or `--system-output-interface none` on the CLI.
* **Human players:**  
  Copy the player block from the example above into your config file.

---

## Testing
1. Unit tests: `pytest -q` — all pass.  
2. Manual:
   1. `python -m langchain_werewolf -c examples/config/config_human_participates_example1.json`
   2. Verify prompts appear with ~2 s delay for the human player only.
   3. Run with `--system-output-interface none` to ensure headless execution completes without errors.

---

## Checklist
- [x] New example configuration added  
- [x] Unit tests updated and passing  
- [x] Lint / type-check (`ruff`, `mypy`) clean  
- [x] Docs & help text refreshed  
